### PR TITLE
chore: built dependencies change

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,5 +28,13 @@
   },
   "engines": {
     "node": ">=22"
+  },
+  "pnpm": {
+    "onlyBuiltDependencies": [
+      "esbuild",
+      "@parcel/watcher",
+      "sharp",
+      "@tailwindcss/oxide"
+    ]
   }
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,6 +1,0 @@
-onlyBuiltDependencies:
-  - esbuild
-  - '@parcel/watcher'
-  - sharp
-  - '@tailwindcss/oxide'
-


### PR DESCRIPTION
per release notes https://github.com/pnpm/pnpm/releases/tag/v10.0.0 use the package json to specify what package are allowed to use hooks. I prefer the package json for this project because its not a monorepo.